### PR TITLE
フィードページの実装

### DIFF
--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,0 +1,81 @@
+import { Image, Box, Card, CardBody, Center, Flex, Heading, Spacer, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack } from '@chakra-ui/react';
+import type { NextPageWithLayout } from 'next';
+import { Layout } from 'shared/components/layouts/Layout';
+
+const Feed: NextPageWithLayout = () => {
+  return (
+    <Box minHeight={'100vh'} width={'100vw'}>
+      <TemporaryHeader />
+      <FeedTab />
+    </Box>
+  );
+};
+
+const TemporaryHeader = () => (
+  <Flex minWidth='max-content' alignItems='center' gap='2' paddingX='4' paddingTop='8'>
+    <Box>
+      <Heading size='lg'>Your Feed</Heading>
+    </Box>
+    <Spacer />
+    <Center bg='gray' h='16' w='16' alignContent='center' borderRadius='50%' marginRight='2'>image</Center>
+  </Flex>
+)
+
+const FeedTab = () => {
+  return (
+    <Tabs paddingTop='4' isFitted variant='enclosed'>
+      <TabList>
+        <Tab>
+          <Text fontWeight='semibold'>Random</Text>
+        </Tab>
+        <Tab>
+          <Text fontWeight='semibold'>Chronological</Text>
+        </Tab>
+      </TabList>
+      <TabPanels>
+        <RandomFeedTabPanel />
+        <TabPanel>
+          Chronological panel content is here.
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+}
+
+const RandomFeedTabPanel = () => {
+  return (
+    <TabPanel>
+      <VStack spacing={4}>
+        <ChekiCard />
+        <ChekiCard />
+        <ChekiCard />
+      </VStack>
+    </TabPanel>
+  );
+}
+
+const ChekiCard = () => {
+  return (
+    <Card maxW='sm'>
+      <CardBody>
+        <Image
+          src='https://images.unsplash.com/photo-1555041469-a586c61ea9bc?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80'
+          alt='Green double couch with wooden legs'
+          borderRadius='sm'
+        />
+        <Stack mt='6' spacing='3'>
+          <Heading size='md'>Living room Sofa</Heading>
+          <Text>
+            This sofa is perfect for modern tropical spaces, baroque inspired
+            spaces, earthy toned spaces and for people who love a chic design with a
+            sprinkle of vintage design.
+          </Text>
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+}
+
+Feed.getLayout = page => <Layout>{page}</Layout>;
+
+export default Feed;

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,5 +1,6 @@
 import { Image, Box, Card, CardBody, Center, Flex, Heading, Spacer, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack } from '@chakra-ui/react';
 import type { NextPageWithLayout } from 'next';
+import { ChekiCard } from 'shared/components/feed/ChekiCard';
 import { Layout } from 'shared/components/layouts/Layout';
 
 const Feed: NextPageWithLayout = () => {
@@ -45,16 +46,19 @@ const FeedTab = () => {
 const RandomFeedTabPanel = () => {
   return (
     <TabPanel>
-      <VStack spacing={4}>
+      <VStack spacing={4} paddingBottom={36}>
+
         <ChekiCard />
         <ChekiCard />
-        <ChekiCard />
+
+        <SoferCard />
+        <SoferCard />
       </VStack>
     </TabPanel>
   );
 }
 
-const ChekiCard = () => {
+const SoferCard = () => {
   return (
     <Card maxW='sm'>
       <CardBody>

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,6 +1,7 @@
-import { Box, Center, Flex, Heading, Spacer, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack } from '@chakra-ui/react';
+import { Box, Center, Flex, HStack, Heading, Spacer, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack } from '@chakra-ui/react';
 import type * as next from 'next';
 import { ChekiCard } from 'shared/components/feed/ChekiCard';
+import { StickeyNoteCard } from 'shared/components/feed/StickeyNoteCard';
 import { Layout } from 'shared/components/layouts/Layout';
 
 const Feed: next.NextPageWithLayout = () => {
@@ -49,12 +50,14 @@ const RandomFeedTabPanel = () => {
       <VStack spacing={4} paddingBottom={36}>
 
         <ChekiCard />
+        <StickeyNoteCard />
         <ChekiCard />
 
       </VStack>
-    </TabPanel>
+    </TabPanel >
   );
 }
+
 
 Feed.getLayout = page => <Layout>{page}</Layout>;
 

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,9 +1,9 @@
-import { Image, Box, Card, CardBody, Center, Flex, Heading, Spacer, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack } from '@chakra-ui/react';
-import type { NextPageWithLayout } from 'next';
+import { Box, Center, Flex, Heading, Spacer, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack } from '@chakra-ui/react';
+import type * as next from 'next';
 import { ChekiCard } from 'shared/components/feed/ChekiCard';
 import { Layout } from 'shared/components/layouts/Layout';
 
-const Feed: NextPageWithLayout = () => {
+const Feed: next.NextPageWithLayout = () => {
   return (
     <Box minHeight={'100vh'} width={'100vw'}>
       <TemporaryHeader />
@@ -51,32 +51,8 @@ const RandomFeedTabPanel = () => {
         <ChekiCard />
         <ChekiCard />
 
-        <SoferCard />
-        <SoferCard />
       </VStack>
     </TabPanel>
-  );
-}
-
-const SoferCard = () => {
-  return (
-    <Card maxW='sm'>
-      <CardBody>
-        <Image
-          src='https://images.unsplash.com/photo-1555041469-a586c61ea9bc?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80'
-          alt='Green double couch with wooden legs'
-          borderRadius='sm'
-        />
-        <Stack mt='6' spacing='3'>
-          <Heading size='md'>Living room Sofa</Heading>
-          <Text>
-            This sofa is perfect for modern tropical spaces, baroque inspired
-            spaces, earthy toned spaces and for people who love a chic design with a
-            sprinkle of vintage design.
-          </Text>
-        </Stack>
-      </CardBody>
-    </Card>
   );
 }
 

--- a/src/shared/components/feed/ChekiCard.tsx
+++ b/src/shared/components/feed/ChekiCard.tsx
@@ -1,7 +1,8 @@
-import { Box, Card, CardBody, Heading, Stack, Text, Image, HStack, Spacer, Button, Flex, Avatar } from '@chakra-ui/react';
+import { Box, Card, CardBody, Heading, Stack, Text, Image, HStack, Spacer, Button } from '@chakra-ui/react';
 import { motion } from 'framer-motion'
 import Link from 'next/link';
 import React from 'react'
+import { UserCardBanner } from './UserCardBanner';
 
 type Member = {
   screenName: string;
@@ -111,22 +112,5 @@ const BackFace = () => {
         </Link>
       </CardBody>
     </Card>
-  );
-}
-
-type UserCardBannerProps = {
-  screenName: string;
-  iconImageUrl: string;
-}
-
-const UserCardBanner = ({ screenName, iconImageUrl }: UserCardBannerProps) => {
-  return (
-    <Flex flex='1' gap='3' alignItems='center' flexWrap='wrap'>
-      <Avatar size='sm' name={screenName} src={iconImageUrl} />
-
-      <Box>
-        <Heading size='sm'>{screenName}</Heading>
-      </Box>
-    </Flex>
   );
 }

--- a/src/shared/components/feed/ChekiCard.tsx
+++ b/src/shared/components/feed/ChekiCard.tsx
@@ -1,7 +1,7 @@
 import { Box, Card, CardBody, Heading, Stack, Text, Image, HStack, Spacer, Button } from '@chakra-ui/react';
 import { motion } from 'framer-motion'
-import Link from 'next/link';
-import React from 'react'
+import NextLink from 'next/link';
+import React, { useState } from 'react'
 import { UserCardBanner } from './UserCardBanner';
 
 type Member = {
@@ -16,7 +16,7 @@ type Props = {
 }
 
 export const ChekiCard = () => {
-  const [flip, setFlip] = React.useState(true);
+  const [flip, setFlip] = useState(true);
   return (
     <Box>
       {/* カードの領域 */}
@@ -103,13 +103,15 @@ const BackFace = () => {
             <UserCardBanner screenName='Taishi Naka' iconImageUrl={""} />
           </Stack>
         </Stack>
-        <Link href='/' passHref>
+        <NextLink href='/' passHref>
           <Button
-            position={'absolute'} bottom={4} right={4} size={'sm'} padding={6} as={'a'}
+            position={'absolute'} bottom={4} right={4} size={'sm'} padding={6}
+            // hack
+            as={'p'}
           >
             詳細を見る
           </Button>
-        </Link>
+        </NextLink>
       </CardBody>
     </Card>
   );

--- a/src/shared/components/feed/ChekiCard.tsx
+++ b/src/shared/components/feed/ChekiCard.tsx
@@ -1,6 +1,18 @@
-import { Box, Card, CardBody, Heading, Stack, Text, Image } from '@chakra-ui/react';
+import { Box, Card, CardBody, Heading, Stack, Text, Image, HStack, Spacer, Button, Flex, Avatar } from '@chakra-ui/react';
 import { motion } from 'framer-motion'
+import Link from 'next/link';
 import React from 'react'
+
+type Member = {
+  screenName: string;
+  iconImageUrl: string;
+}
+type Props = {
+  imageUrl: string;
+  caption: string;
+  memoryTimeContext: string; // いつの思い出か
+  members: Member[];
+}
 
 export const ChekiCard = () => {
   const [flip, setFlip] = React.useState(true);
@@ -48,6 +60,11 @@ export const ChekiCard = () => {
   )
 }
 
+type FrontFaceProps = {
+  imageUrl: string;
+  caption: string;
+  memoryTimeContext: string;
+}
 
 const FrontFace = () => {
   return (
@@ -58,31 +75,58 @@ const FrontFace = () => {
           alt='Green double couch with wooden legs'
           borderRadius='sm'
         />
-        <Stack mt='6' spacing='3'>
-          <Heading size='md'>Front side</Heading>
-          <Text>
-            This sofa is perfect for modern tropical spaces, baroque inspired
-            spaces, earthy toned spaces and for people who love a chic design with a
-            sprinkle of vintage design.
-          </Text>
-        </Stack>
+        <HStack mt='4'>
+          <Heading size={"sm"} maxWidth={"70%"}>ふかふかソファに座ってたのしい談笑</Heading>
+          <Spacer />
+          <Text fontSize="xs">寮生活時代</Text>
+        </HStack>
       </CardBody>
     </Card>
   );
 }
+
+type BackFaceProps = {
+  memoryTimeContext: string;
+  members: Member[];
+}
+
 const BackFace = () => {
   return (
-    <Card maxW='sm' position='absolute' height={'100%'} width={'100%'}>
-      <CardBody>
-        <Stack mt='6' spacing='3'>
-          <Heading size='md'>Back side</Heading>
-          {/* <Text>
-            This sofa is perfect for modern tropical spaces, baroque inspired
-            spaces, earthy toned spaces and for people who love a chic design with a
-            sprinkle of vintage design.
-          </Text> */}
+    <Card maxW='sm' position='absolute' height={'100%'} width={'100%'} >
+      <CardBody overflow="hidden" position={'relative'}>
+        <Stack>
+          <Heading size='sm'>思い出のメンバー</Heading>
+          <Stack marginTop={2} paddingLeft={2} spacing={4}>
+            <UserCardBanner screenName='Daiki Ito' iconImageUrl={""} />
+            <UserCardBanner screenName='Manato Kato' iconImageUrl={""} />
+            <UserCardBanner screenName='Taishi Naka' iconImageUrl={""} />
+          </Stack>
         </Stack>
+        <Link href='/' passHref>
+          <Button
+            position={'absolute'} bottom={4} right={4} size={'sm'} padding={6} as={'a'}
+          >
+            詳細を見る
+          </Button>
+        </Link>
       </CardBody>
     </Card>
+  );
+}
+
+type UserCardBannerProps = {
+  screenName: string;
+  iconImageUrl: string;
+}
+
+const UserCardBanner = ({ screenName, iconImageUrl }: UserCardBannerProps) => {
+  return (
+    <Flex flex='1' gap='3' alignItems='center' flexWrap='wrap'>
+      <Avatar size='sm' name={screenName} src={iconImageUrl} />
+
+      <Box>
+        <Heading size='sm'>{screenName}</Heading>
+      </Box>
+    </Flex>
   );
 }

--- a/src/shared/components/feed/ChekiCard.tsx
+++ b/src/shared/components/feed/ChekiCard.tsx
@@ -1,0 +1,85 @@
+import { Box, Card, CardBody, Heading, Stack, Text, Image } from '@chakra-ui/react';
+import { motion } from 'framer-motion'
+import React from 'react'
+
+export const ChekiCard = () => {
+  const [flip, setFlip] = React.useState(true);
+  return (
+    <Box width={'100%'}>
+      {/* カードの領域 */}
+      <motion.div
+        transition={{ duration: 0.3 }}
+        animate={{ rotateY: flip ? 0 : 180 }}
+        onClick={() => setFlip((prevState) => !prevState)}
+      >
+        {/* both side content */}
+        <motion.div
+          transition={{ duration: 0.3 }}
+          animate={{ rotateY: flip ? 0 : 180 }}
+          style={{ width: '100%', height: '100%', position: 'relative' }}
+        >
+          {/* frontside content */}
+          <motion.div
+            style={{ backfaceVisibility: 'hidden', position: 'absolute', width: '100%', height: '100%' }}
+            transition={{ duration: 0.3 }}
+            animate={{ rotateY: flip ? 0 : 180 }}
+          >
+            <FrontFace />
+          </motion.div>
+
+          {/* backside content */}
+          <motion.div
+            style={{ backfaceVisibility: 'hidden', position: 'absolute', width: '100%', height: '100%' }}
+            initial={{ rotateY: 180 }}
+            animate={{ rotateY: flip ? 180 : 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <BackFace />
+          </motion.div>
+          {/* カードがある領域の高さを維持するため、不可視のカード要素を導入 */}
+          <Box visibility={'hidden'}>
+            <FrontFace />
+          </Box>
+        </motion.div>
+      </motion.div>
+    </Box>
+  )
+}
+
+const FrontFace = () => {
+  return (
+    <Card maxW='sm'>
+      <CardBody>
+        <Image
+          src='https://images.unsplash.com/photo-1555041469-a586c61ea9bc?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80'
+          alt='Green double couch with wooden legs'
+          borderRadius='sm'
+        />
+        <Stack mt='6' spacing='3'>
+          <Heading size='md'>Front side</Heading>
+          <Text>
+            This sofa is perfect for modern tropical spaces, baroque inspired
+            spaces, earthy toned spaces and for people who love a chic design with a
+            sprinkle of vintage design.
+          </Text>
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+}
+const BackFace = () => {
+  return (
+    <Card maxW='sm' position='absolute' height={'100%'} width={'100%'}>
+      <CardBody>
+        <Stack mt='6' spacing='3'>
+          <Heading size='md'>Back side</Heading>
+          {/* <Text>
+            This sofa is perfect for modern tropical spaces, baroque inspired
+            spaces, earthy toned spaces and for people who love a chic design with a
+            sprinkle of vintage design.
+          </Text> */}
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/shared/components/feed/ChekiCard.tsx
+++ b/src/shared/components/feed/ChekiCard.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 export const ChekiCard = () => {
   const [flip, setFlip] = React.useState(true);
   return (
-    <Box width={'100%'}>
+    <Box>
       {/* カードの領域 */}
       <motion.div
         transition={{ duration: 0.3 }}
@@ -36,15 +36,18 @@ export const ChekiCard = () => {
           >
             <BackFace />
           </motion.div>
+
           {/* カードがある領域の高さを維持するため、不可視のカード要素を導入 */}
           <Box visibility={'hidden'}>
             <FrontFace />
           </Box>
+
         </motion.div>
       </motion.div>
     </Box>
   )
 }
+
 
 const FrontFace = () => {
   return (

--- a/src/shared/components/feed/StickeyNoteCard.tsx
+++ b/src/shared/components/feed/StickeyNoteCard.tsx
@@ -1,0 +1,20 @@
+import { HStack, Heading, Spacer, Text } from "@chakra-ui/react";
+
+export const StickeyNoteCard = () => {
+  return (
+    <HStack
+      width={'100%'}
+      maxWidth={'sm'}
+      minHeight={20}
+      paddingX={4}
+      paddingY={4}
+      bgColor='#FFADAD'
+      shadow="md"
+      transform="rotate(1deg)"
+    >
+      <Heading size='md' fontWeight='semibold'>早朝龍泉寺</Heading>
+      <Spacer />
+      <Text fontSize='xs'>寮生活時代</Text>
+    </HStack>
+  );
+}

--- a/src/shared/components/feed/UserCardBanner.tsx
+++ b/src/shared/components/feed/UserCardBanner.tsx
@@ -1,0 +1,18 @@
+import { Avatar, Box, Flex, Heading } from "@chakra-ui/react";
+
+type Props = {
+  screenName: string;
+  iconImageUrl: string;
+}
+
+export const UserCardBanner = ({ screenName, iconImageUrl }: Props) => {
+  return (
+    <Flex flex='1' gap='3' alignItems='center' flexWrap='wrap'>
+      <Avatar size='sm' name={screenName} src={iconImageUrl} />
+
+      <Box>
+        <Heading size='sm'>{screenName}</Heading>
+      </Box>
+    </Flex>
+  );
+}

--- a/src/shared/components/layouts/BottomMenu.tsx
+++ b/src/shared/components/layouts/BottomMenu.tsx
@@ -4,6 +4,7 @@ import { BiPhotoAlbum } from 'react-icons/bi';
 import { MdOutlineAddBox } from 'react-icons/md';
 import { IoSearch } from 'react-icons/io5';
 import { FiHome } from 'react-icons/fi';
+import Link from 'next/link';
 
 export const BottomMenu = () => {
   return (
@@ -15,7 +16,9 @@ export const BottomMenu = () => {
       borderColor={'gray.300'}
       bg={'white'}
     >
-      <Icon as={FiHome} boxSize={'32px'} />
+      <Link href='feed' passHref>
+        <Icon as={FiHome} boxSize={'32px'} />
+      </Link>
       <Icon as={IoSearch} boxSize={'32px'} />
       <Icon as={MdOutlineAddBox} boxSize={'32px'} />
       <Icon as={BiPhotoAlbum} boxSize={'32px'} />

--- a/src/shared/components/layouts/BottomMenu.tsx
+++ b/src/shared/components/layouts/BottomMenu.tsx
@@ -12,7 +12,8 @@ export const BottomMenu = () => {
       w='100vw'
       justifyContent={'space-between'}
       borderTop={'1px'}
-      borderColor={'gray.100'}
+      borderColor={'gray.300'}
+      bg={'white'}
     >
       <Icon as={FiHome} boxSize={'32px'} />
       <Icon as={IoSearch} boxSize={'32px'} />


### PR DESCRIPTION
フィードページの

- ヘッダー
- フィードタブ
- チェキカード （`ChekiCard`）
- 付箋カード （`StickyNoteCard`）

を実装しました

表示に使ったデータはほとんどハードコードしています。

## スクショ
フィード画面
<img width="300px"  src="https://github.com/Dz0526/memorial-ateliear-front/assets/62321668/5030a1e9-77ec-40f3-bb45-e9e76d32be07">

チェキカードをタップするとフリップする
<img src="https://github.com/Dz0526/memorial-ateliear-front/assets/62321668/9f659991-6bd7-46f6-8cf8-179dabcb537a" width="300px" >

