### PR TITLE
remove `search` and `albums` icons from `BottomMenu` bar

### DIFF
--- a/src/shared/components/layouts/BottomMenu.tsx
+++ b/src/shared/components/layouts/BottomMenu.tsx
@@ -1,15 +1,14 @@
 import { HStack, Icon } from '@chakra-ui/react';
 import { RiTreasureMapLine } from 'react-icons/ri';
-import { BiPhotoAlbum } from 'react-icons/bi';
 import { MdOutlineAddBox } from 'react-icons/md';
-import { IoSearch } from 'react-icons/io5';
 import { FiHome } from 'react-icons/fi';
 import Link from 'next/link';
 
 export const BottomMenu = () => {
   return (
     <HStack
-      p={'16px'}
+      py={'16px'}
+      px={'12%'}
       w='100vw'
       justifyContent={'space-between'}
       borderTop={'1px'}
@@ -19,11 +18,9 @@ export const BottomMenu = () => {
       <Link href='/feed' passHref>
         <Icon as={FiHome} boxSize={'32px'} />
       </Link>
-      <Icon as={IoSearch} boxSize={'32px'} />
       <Link href={'/memory/create'} passHref>
         <Icon as={MdOutlineAddBox} boxSize={'32px'} />
       </Link>
-      <Icon as={BiPhotoAlbum} boxSize={'32px'} />
       <Link href='/quest' passHref>
         <Icon as={RiTreasureMapLine} boxSize={'32px'} />
       </Link>


### PR DESCRIPTION
虫眼鏡とアルバムのアイコンを下部メニューバーから削除